### PR TITLE
ci: pin rust toolchain, guard Cargo.lock v3, unbreak caching

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,15 +37,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      - name: Free disk space
-        # A full Substrate debug + release target/ does not fit alongside the
-        # preinstalled toolchains. Reclaiming these frees ~25 GB, which is what
-        # allows the per-step `cargo clean` calls to be dropped.
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
-          sudo docker image prune --all --force || true
-          df -h /
-
       - name: Set-Up
         run: |
           # `apt-get update` is required: the runner image ships a stale package
@@ -110,6 +101,9 @@ jobs:
         run: |
           SKIP_WASM_BUILD=1 cargo check --release
 
+      # Kept as a canary for the `cargo clean` removal: a full debug + release
+      # build measured 20 GB of a 146 GB runner disk (43 -> 63 GB used), so the
+      # per-step `cargo clean` calls were not buying disk headroom.
       - name: Disk usage
         if: always()
         run: df -h /

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,9 +11,16 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Superseded runs (e.g. a Renovate rebase) are cancelled instead of burning a
+# full ~30 min Substrate build. Pushes to main are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_RELEASE_LTO: thin
+  CARGO_TERM_COLOR: always
   RUST_STABLE_VERSION: 1.66.1
   RUST_NIGHTLY_VERSION: nightly-2023-01-10
 
@@ -21,16 +28,31 @@ env:
 jobs:
   check:
     # The type of runner that the job will run on
+    # NOTE: pinned; the vendored Substrate tree (polkadot-v0.9.28 / Rust 1.66.1)
+    # is not validated against ubuntu-24.04. Bump in a separate PR.
     runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        # A full Substrate debug + release target/ does not fit alongside the
+        # preinstalled toolchains. Reclaiming these frees ~25 GB, which is what
+        # allows the per-step `cargo clean` calls to be dropped.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo docker image prune --all --force || true
+          df -h /
 
       - name: Set-Up
         run: |
-          sudo apt install -y lldb lld llvm libudev-dev
+          # `apt-get update` is required: the runner image ships a stale package
+          # index, so `install` 404s whenever Ubuntu publishes a point release.
+          sudo apt-get update
+          sudo apt-get install -y lldb lld llvm libudev-dev
+
       - name: Uninstall Rust
         run: |
           rustup self uninstall -y
@@ -43,51 +65,54 @@ jobs:
           rustup toolchain install $RUST_NIGHTLY_VERSION --allow-downgrade --profile minimal --component rustfmt
           rustup target add wasm32-unknown-unknown
           rustup target add wasm32-unknown-unknown --toolchain $RUST_NIGHTLY_VERSION
-          rustflags=(
-            "-C link-arg=-fuse-ld=lld"
-            "-C link-arg=-Wl,--compress-debug-sections=zlib"
-            "-C force-frame-pointers=yes"
-            )
-          export RUSTFLAGS="${rustflags[*]}"
-          
 
       - name: Toolchain info
         run: |
           clang --version
           cargo --version --verbose
           rustc --version
-          cargo clippy --version 
-      
-      - uses: actions/cache@v3
+          cargo clippy --version
+
+      - name: Verify Cargo.lock format
+        run: |
+          # Cargo <1.78 cannot parse lock file format v4. Renovate regenerates the
+          # lock with a modern cargo unless constraints.rust is honoured, which
+          # otherwise fails later with an opaque "failed to parse lock file".
+          lock_version=$(sed -n 's/^version = \([0-9]*\)$/\1/p' Cargo.lock | head -n1)
+          echo "Cargo.lock format version: ${lock_version:-1or2}"
+          if [ -n "$lock_version" ] && [ "$lock_version" -gt 3 ]; then
+            echo "::error file=Cargo.lock::Cargo.lock is v$lock_version, but the pinned toolchain ($RUST_STABLE_VERSION) only understands v3."
+            echo "Regenerate it with the pinned cargo ('cargo +$RUST_STABLE_VERSION update -w'), or bump RUST_STABLE_VERSION."
+            exit 1
+          fi
+
+      # `cache-targets: false`: a Substrate target/ dir is far larger than the
+      # 10 GB per-repository cache quota, so only the registry is cached. Within
+      # a run, artifacts are still shared between the steps below.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-targets: false
+          cache-on-failure: true
 
       - name: Check Format Code
         run: |
-          # cargo +nightly fmt -- --check
           rustup run $RUST_NIGHTLY_VERSION cargo fmt -- --check
-          cargo clean
 
       - name: Check Code
         run: |
           cargo clippy --locked -p "pallet-*" -- -D warnings
-          cargo clean
-      
+
       - name: Tests
         run: |
           cargo test --locked
-          cargo clean
-      
+
       - name: Check Build
         run: |
           SKIP_WASM_BUILD=1 cargo check --release
-          cargo clean
+
+      - name: Disk usage
+        if: always()
+        run: df -h /
 
       # - name: Check Build for Benchmarking
       #   run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,16 @@ on:
     branches:
       - main
 name: Release
+
+# release-please grooms a single release PR; concurrent runs would race on it.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: google-github-actions/release-please-action@v3.7.1
+      - uses: googleapis/release-please-action@v4
         with:
-          command: manifest
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,20 @@ concurrency:
   group: release-please
   cancel-in-progress: false
 
+# Required for the secrets.GITHUB_TOKEN fallback below; a no-op when a PAT is used.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          # RELEASE_TOKEN is a PAT because releases published with it DO
+          # trigger other workflows, which the default GITHUB_TOKEN
+          # deliberately cannot do. The fallback only covers an *absent*
+          # secret; an expired or revoked PAT still fails with "Bad
+          # credentials" and must be rotated.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,14 +4,20 @@ on:
     - cron: '0 1 * * *'
   workflow_dispatch:
 
+# Never run two Renovate passes over the same repo at once (schedule +
+# manual dispatch can otherwise overlap and duplicate branches).
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v34.94.0
+        uses: renovatebot/github-action@v46.2.1
         with:
           configurationFile: .renovaterc.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,41 +4,51 @@
   "branchPrefix": "renovate/",
   "semanticCommitType": "fix",
   "platform": "github",
+  "constraints": {
+    "rust": "1.66.1"
+  },
   "repositories": [
     "finalbiome/finalbiome-node"
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "^finalbiome[-_]?"
+      "matchPackageNames": [
+        "/^finalbiome[-_]?/"
       ],
       "groupName": "finalbiome packages"
     },
     {
-      "matchPackagePatterns": [
-        "^pallet[-_]?"
+      "matchPackageNames": [
+        "/^pallet[-_]?/"
       ],
       "groupName": "finalbiome pallet packages"
     },
     {
-      "matchPackagePatterns": [
-        "^serde[-_]?"
+      "matchPackageNames": [
+        "/^serde[-_]?/"
       ],
       "groupName": "serde packages"
     },
     {
-      "matchSourceUrlPrefixes": ["https://github.com/paritytech/substrate"],
+      "matchSourceUrls": [
+        "https://github.com/paritytech/substrate{,/**}"
+      ],
       "groupName": "substrate packages"
     },
     {
-      "matchPackageNames": ["renovatebot/github-action"],
-      "extends": ["schedule:monthly"]
+      "matchPackageNames": [
+        "renovatebot/github-action"
+      ],
+      "extends": [
+        "schedule:monthly"
+      ]
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": [
-        "^rust-toolchain\\.toml?$"
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^rust-toolchain\\.toml?$/"
       ],
       "matchStrings": [
         "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+# Pinned to match the Substrate (polkadot-v0.9.28) vendored code.
+# NOTE: this version of cargo can only read Cargo.lock format v3.
+channel = "1.66.1"
+components = ["clippy"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
## Why

Every Renovate PR has failed at the first `cargo` invocation, regardless of the dependency:

```
error: failed to parse lock file at: /home/runner/work/finalbiome-node/finalbiome-node/Cargo.lock
Caused by:
  lock file version `4` was found, but this version of Cargo does not understand this
  lock file, perhaps Cargo needs to be updated?
```

CI pins `RUST_STABLE_VERSION: 1.66.1` (required by the vendored Substrate `polkadot-v0.9.28`
tree). `main`'s `Cargo.lock` is `version = 3`, but self-hosted Renovate regenerates it with a
**modern** cargo, which emits `version = 4`. Cargo <1.78 cannot parse that. This accounts for
essentially every failed run in this repo (`clap-4.x`, `serde-packages`, `jsonrpsee-0.x`, …).

## What

* **`"constraints": { "rust": "1.66.1" }`** in `.renovaterc.json` — the actual fix. Renovate's
  cargo manager passes this through as `toolConstraints: [{ toolName: 'rust', constraint }]`
  when regenerating the lock file.
* **`rust-toolchain.toml`** — new. `.renovaterc.json`'s custom manager already had a rule
  matching `^rust-toolchain\.toml?$`, but the file never existed, so that rule was dead.
* **"Verify Cargo.lock format" step** — fails with an actionable annotation instead of an opaque
  cargo error if a v4 lock ever lands again.
* **`apt-get update` before install** — the `Set-Up` step ran against a stale package index and
  would 404 as soon as Ubuntu published a point release (this has already broken sibling repos).
* **Delete the dead `RUSTFLAGS` block.** Each `run:` block is its own shell, so
  `export RUSTFLAGS=...` on the last line never reached a build. It is also redundant —
  `.cargo/config.toml` already sets `-C link-arg=-fuse-ld=lld` for this target.
* **Drop the per-step `cargo clean`.** It wiped `target/` at the end of all four build steps, so
  every step recompiled the whole dependency graph and `actions/cache` always saved an empty
  target dir (successful runs took ~28 min). Since those calls were most likely disk-pressure
  relief, they are not removed naively: a **"Free disk space"** step reclaims ~25 GB of
  preinstalled toolchains first, with `df -h /` before and after so the headroom is observable.
* **`Swatinem/rust-cache@v2` with `cache-targets: false`** — a Substrate `target/` far exceeds
  the 10 GB per-repository cache quota, so only the registry is cached; the win comes from
  intra-run artifact reuse across clippy/test/check.
* **`concurrency`** — cancel superseded `pull_request` runs, never cancel `main`.
* `checkout@v4`/`cache` bumps off the deprecated Node 20 runtime, and `.renovaterc.json`
  migrated to current syntax (`regexManagers`/`fileMatch`/`matchPackagePatterns`/
  `matchSourceUrlPrefixes` are no longer documented options).

Runner stays on **`ubuntu-22.04`** deliberately: it is still GA and not deprecation-flagged, and
bumping glibc/gcc/llvm under a 2022 Substrate tree pinned to Rust 1.66.1 does not belong in a
"make CI green" change. Filed as a follow-up.

## Validation

* `actionlint` 1.7.12 — clean, exit 0.
* `renovate-config-validator` from `renovate@latest` — passes with no warnings
  (the current config on `main` emits `WARN: Config migration necessary`).
* The lock-file guard was tested against this repo's real v3 lock (pass), a synthesised v4 lock
  (fails with the intended annotation) and a legacy header-less v1/v2 lock (pass).