### PR TITLE
ci: make Renovate MSRV-aware for the pinned 1.66.1 toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,9 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Dependency updates are handled by self-hosted Renovate
+# (.renovaterc.json + .github/workflows/renovate.yml), which is the only updater
+# that honours `constraints.rust = 1.66.1` (the MSRV of the vendored
+# polkadot-v0.9.28 Substrate tree). Dependabot has no MSRV awareness and opened
+# PRs that can never compile, so the cargo ecosystem is intentionally not listed
+# here. Do not re-enable it without removing the cargo manager from Renovate.
 
 version: 2
-updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+updates: []

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,3 +21,10 @@ jobs:
         with:
           configurationFile: .renovaterc.json
           token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          # Let containerbase install the toolchain declared in
+          # `.renovaterc.json` -> constraints.rust (1.66.1) instead of using the
+          # modern cargo baked into the image. Without this, lock-file updates
+          # are resolved by cargo >=1.78 and land as `version = 4`, which the
+          # pinned CI toolchain refuses to parse.
+          RENOVATE_BINARY_SOURCE: install

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -7,10 +7,35 @@
   "constraints": {
     "rust": "1.66.1"
   },
+  "description": [
+    "The vendored Substrate tree (polkadot-v0.9.28) only builds on Rust 1.66.1.",
+    "'constraints' alone is NOT enough: without constraintsFiltering Renovate",
+    "still proposes releases whose crates.io 'rust_version' (MSRV) is higher,",
+    "e.g. hex-literal 1.1.0 (MSRV 1.85) or hashbrown 0.17.1 (MSRV 1.85.0),",
+    "which cargo 1.66 cannot even parse ('older than the 2024 edition')."
+  ],
+  "constraintsFiltering": "strict",
   "repositories": [
     "finalbiome/finalbiome-node"
   ],
   "packageRules": [
+    {
+      "description": "The Rust toolchain is pinned to the Substrate fork; never bump it automatically. Surfaced on the Dependency Dashboard for manual approval only.",
+      "matchDepNames": [
+        "rust"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "No cargo major bump can work on a frozen 2022 Substrate stack (clap v4, hex-literal v1, ...). Require manual approval instead of opening PRs that can never go green.",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
     {
       "matchPackageNames": [
         "/^finalbiome[-_]?/"

--- a/pallets/support/src/characteristics/bettor.rs
+++ b/pallets/support/src/characteristics/bettor.rs
@@ -22,7 +22,7 @@ impl AssetCharacteristic for Bettor {
       return false;
     }
     // count if winings must be more than 0
-    if self.winnings.len() == 0 {
+    if self.winnings.is_empty() {
       return false;
     }
     // rounds must be in [1..BETTOR_MAX_NUMBER_OF_ROUNDS]

--- a/pallets/support/src/characteristics/purchased.rs
+++ b/pallets/support/src/characteristics/purchased.rs
@@ -10,7 +10,7 @@ pub struct Purchased {
 impl AssetCharacteristic for Purchased {
   fn is_valid(&self) -> bool {
     // number of offers must be more than 0
-    if self.offers.len() == 0 {
+    if self.offers.is_empty() {
       return false;
     }
     // price must be more than 0


### PR DESCRIPTION
## Problem

`main` is green, but **every** open Renovate PR is red. All of them fail for the same underlying reason: Renovate proposes dependencies that the pinned toolchain (`rust-toolchain.toml` = 1.66.1, required by the vendored Substrate `polkadot-v0.9.28` tree) cannot build.

`constraints.rust = "1.66.1"` was already set, but **Renovate ignores `constraints` when selecting versions unless `constraintsFiltering` is enabled** (default: `none`). The crates.io index does carry the metadata needed:

| crate | version | `rust_version` |
|---|---|---|
| `hex-literal` | 0.4.1 | 1.57 OK |
| `hex-literal` | 1.1.0 | 1.85 FAIL |
| `hashbrown` | 0.17.1 | 1.85.0 FAIL |
| `clap` | 4.6.5 | 1.85 FAIL |

cargo 1.66 cannot even parse those manifests, so the runs die during dependency resolution:

```
error: failed to download `hashbrown v0.17.1`
Caused by: failed to parse the `edition` key
Caused by: this version of Cargo is older than the `2024` edition,
           and only supports `2015`, `2018`, and `2021` editions.
```

## Observed failure modes

| Run | PR | Cause |
|---|---|---|
| 31070717207 | #108 codec 3.7.5 | transitive `hashbrown 0.17.1`, edition 2024 |
| 30996766143 | #97 hex-literal v1 | `hex-literal 1.1.0`, edition 2024 |
| 31070519104 | #107 rust 1.97.1 | toolchain bump -> new `clippy::len_zero` errors |
| 30996748690 | #45 clap v4 | 24x `E0277`, Substrate 0.9.28 is built against clap 3 |

The `Cargo.lock` v3 guard from #104 works correctly -- every failing run now prints `Cargo.lock format version: 3` and passes that step.

## Changes

* **`constraintsFiltering: "strict"`** -- drop releases whose declared MSRV exceeds `constraints.rust`. Fixes the edition-2024 class outright.
* **Dashboard approval for the `rust` dep** -- the custom manager added in #104 made `rust-toolchain.toml` an update target, and Renovate immediately proposed 1.97.1 (#107). The pin is deliberate; it should never be bumped automatically. Still visible on the Dependency Dashboard.
* **Dashboard approval for cargo majors** -- some breakage is API-level, not MSRV (clap v4 vs Substrate 0.9.28), so filtering alone cannot catch it.
* **`RENOVATE_BINARY_SOURCE: install`** -- makes containerbase install the Rust from `constraints.rust` so lock files are resolved by cargo 1.66.1. Previously a modern cargo did the resolution, which is what produced `Cargo.lock` v4 and pulled edition-2024 transitive deps. A bad resolution now fails inside Renovate instead of landing as a red PR.
* **Dependabot cargo ecosystem removed** -- no MSRV awareness, duplicated Renovate, and is the source of the 2022-era `dependabot/cargo/*` PRs.
* **`clippy::len_zero` fixes** in `pallet-support` (`len() == 0` -> `is_empty()`) -- the only two lints blocking a future toolchain bump. Harmless under 1.66.

`.renovaterc.json` validated with `renovate-config-validator`.

## Follow-up (not fixable by config)

This only stops the bleeding. The stack is frozen on Substrate `polkadot-v0.9.28` / Rust 1.66.1 from 2022, so the set of installable dependency versions keeps shrinking. The durable fix is a `polkadot-sdk` upgrade, tracked separately.
