### PR TITLE
ci: gate cargo updates behind the Dependency Dashboard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,9 +22,13 @@ jobs:
           configurationFile: .renovaterc.json
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          # Let containerbase install the toolchain declared in
-          # `.renovaterc.json` -> constraints.rust (1.66.1) instead of using the
-          # modern cargo baked into the image. Without this, lock-file updates
-          # are resolved by cargo >=1.78 and land as `version = 4`, which the
-          # pinned CI toolchain refuses to parse.
+          # Best-effort: ask containerbase to install the toolchain declared in
+          # `.renovaterc.json` -> constraints.rust rather than using the modern
+          # cargo baked into the image.
+          #
+          # NOTE: this is not sufficient on its own. Run 31091525406 still
+          # resolved `indexmap 2.14.0` (edition 2024) into the lock for PR #111,
+          # which then failed CI. cargo 1.66 has no MSRV-aware resolver, so
+          # there is no configuration that makes lock regeneration safe here —
+          # that is why cargo updates are behind dependencyDashboardApproval.
           RENOVATE_BINARY_SOURCE: install

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,10 +9,20 @@
   },
   "description": [
     "The vendored Substrate tree (polkadot-v0.9.28) only builds on Rust 1.66.1.",
-    "'constraints' alone is NOT enough: without constraintsFiltering Renovate",
-    "still proposes releases whose crates.io 'rust_version' (MSRV) is higher,",
-    "e.g. hex-literal 1.1.0 (MSRV 1.85) or hashbrown 0.17.1 (MSRV 1.85.0),",
-    "which cargo 1.66 cannot even parse ('older than the 2024 edition')."
+    "Two independent problems follow from that, and they need different fixes:",
+    "1. DIRECT deps whose crates.io 'rust_version' (MSRV) is higher than 1.66.1,",
+    "   e.g. hex-literal 1.1.0 (1.85) or clap 4.x (1.85). Solved by",
+    "   constraintsFiltering: strict, which drops them from lookup entirely.",
+    "2. TRANSITIVE deps pulled in when the lock file is regenerated, e.g. a",
+    "   scale-info 2.11.6 lock update dragging in indexmap 2.14.0 (edition",
+    "   2024). No Renovate setting can fix this: cargo 1.66 has no MSRV-aware",
+    "   resolver, and it refuses to even parse an edition-2024 manifest that is",
+    "   anywhere in the graph. Renovate resolves the lock with its own modern",
+    "   cargo, so the breakage is only discovered by CI.",
+    "Hence every cargo update is gated behind Dependency Dashboard approval:",
+    "they stay visible and one click away, but they no longer open PRs that can",
+    "only ever be red. GitHub Actions updates are left fully automatic.",
+    "Revisit all of this after the polkadot-sdk upgrade."
   ],
   "constraintsFiltering": "strict",
   "repositories": [
@@ -27,12 +37,16 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "No cargo major bump can work on a frozen 2022 Substrate stack (clap v4, hex-literal v1, ...). Require manual approval instead of opening PRs that can never go green.",
+      "description": "Cargo updates are gated: on a frozen 2022 Substrate stack a lock regeneration can always drag an edition-2024 transitive dep into the graph, which cargo 1.66 cannot parse. Approve from the Dependency Dashboard when you actually want to try one.",
       "matchManagers": [
         "cargo"
       ],
-      "matchUpdateTypes": [
-        "major"
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "The CI runner is pinned to ubuntu-22.04 on purpose (see check.yml); the Substrate 0.9.28 build is not validated against 24.04.",
+      "matchDepNames": [
+        "ubuntu"
       ],
       "dependencyDashboardApproval": true
     },


### PR DESCRIPTION
#109 assumed `constraintsFiltering: strict` plus a constraint-matched cargo
would be enough. The first Renovate run after it (31091525406) proved that
wrong: it opened #111 (scale-info 2.11.6, a lock-file-only update) and CI
failed with

    error: failed to download `indexmap v2.14.0`
    Caused by: this version of Cargo is older than the `2024` edition

There are two distinct problems and #109 only fixed the first:

1. Direct deps with a too-high MSRV. `constraintsFiltering` handles these
   correctly — hex-literal 1.x and clap 4.x are now filtered out of lookup,
   and the run deleted the orphaned `renovate/hex-literal-1.x` branch.

2. Transitive deps pulled in when the lock is regenerated. Renovate filters
   the dep it is updating, not the resolution of the whole graph, and
   `RENOVATE_BINARY_SOURCE: install` did not change the outcome. cargo 1.66
   has no MSRV-aware resolver and refuses to parse an edition-2024 manifest
   anywhere in the graph, so any lock regeneration is a coin flip that CI
   pays for.

No configuration fixes (2) while the tree is on polkadot-v0.9.28. So all
cargo updates now require Dependency Dashboard approval: they stay listed
and one click away, but they no longer open PRs that can only be red.
GitHub Actions updates remain fully automatic (checkout v7 merged fine).

Also gate the `ubuntu` runner dep — the ubuntu-22.04 pin in check.yml is
deliberate and #112 silently reverted it.