### PR TITLE
docs: record why Dependabot security updates are disabled

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@
 # polkadot-v0.9.28 Substrate tree). Dependabot has no MSRV awareness and opened
 # PRs that can never compile, so the cargo ecosystem is intentionally not listed
 # here. Do not re-enable it without removing the cargo manager from Renovate.
+#
+# Dependabot *security* updates are configured outside this file (repository
+# settings -> Code security). They are disabled for the same reason: every
+# attempt failed at resolution, e.g.
+#
+#   "Dependabot Updates" / cargo in /. for wasmtime  -> failure
+#
+# Dependabot *alerts* remain enabled, so the vulnerability signal is preserved;
+# only the automatic pull requests are off. The real remediation for those
+# alerts is the polkadot-sdk upgrade, not per-crate bumps.
 
 version: 2
 updates: []


### PR DESCRIPTION
Removing the cargo ecosystem from dependabot.yml in #109 left Dependabot
*security* updates enabled (they are a repository setting, not part of this
file). They immediately produced a wall of failed 'Dependabot Updates' runs
on main — wasmtime, libp2p-gossipsub, rand, rpassword, ... — all failing at
resolution for the same MSRV reason.

Security updates are now disabled in repository settings. Dependabot alerts
stay enabled, so the signal is kept; only the unbuildable PRs are gone.